### PR TITLE
Fixed TWTRComposer does not update its height 

### DIFF
--- a/TwitterKit/TwitterShareExtensionUI/TwitterShareExtensionUI/Private/Composer/TWTRSETweetComposerViewController.m
+++ b/TwitterKit/TwitterShareExtensionUI/TwitterShareExtensionUI/Private/Composer/TWTRSETweetComposerViewController.m
@@ -313,9 +313,13 @@ static void *TSETweetTextKVOCOntext = &TSETweetTextKVOCOntext;
         self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     }
 
-    [_tweetTextViewContainer configureWithTweet:self.dataSource.composedTweet];
-
     [self.dataSource registerCellClassesInTableView:self.tableView];
+}
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+    [_tweetTextViewContainer configureWithTweet:self.dataSource.composedTweet];
 }
 
 - (void)updateViewConstraints


### PR DESCRIPTION
Related issue: https://github.com/twitter/twitter-kit-ios/issues/1

I've moved `configureWithTweet` from `viewDidLoad` to `viewDidLayoutSubview` (in `TWTRSETweetComposerViewController`)

Since the `textView` isn't fully laid out in `viewDidLoad` yet.
This will cause `numberOfLines` in `TWTRSETweetTextView` calculated wrong lines of `textView` and result in wrong container size when we set a text initially for `TWTRSETweetComposerViewController`

See twitter#1 for more information about this issue.