### PR TITLE
Fixes #1: height not initially calculated when initial text is long

### DIFF
--- a/TwitterKit/TwitterShareExtensionUI/TwitterShareExtensionUI/Private/Composer/TWTRSETweetTextViewContainer.m
+++ b/TwitterKit/TwitterShareExtensionUI/TwitterShareExtensionUI/Private/Composer/TWTRSETweetTextViewContainer.m
@@ -183,6 +183,13 @@ static const UIEdgeInsets kComposeTextViewTextContainerInsets = { .top = 8, .lef
     self.characterCounterLabel.textColor = ([self.tweet isNearOrOverCharacterLimit]) ? _characterCountOverLimitColor : _characterCountBelowLimitColor;
 }
 
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    [self _tseui_updateLineCount];
+}
+
 - (void)_tseui_updateLineCount
 {
     NSUInteger textViewNumberOfLines = _textView.numberOfLines;


### PR DESCRIPTION
I reproduced this in the Twitter for iOS share extension on iOS 11. I think this is the simplest fix.

`TWTRSETweetTextViewContainer` is not re-calculating its number of lines when it's re-laid out.

Before:
![simulator screen shot - iphone 8 - 2017-12-20 at 11 32 03](https://user-images.githubusercontent.com/666807/34224934-6c03ba42-e579-11e7-9e31-0e4ac6e8d715.png)

After:
![simulator screen shot - iphone 8 - 2017-12-20 at 11 30 39](https://user-images.githubusercontent.com/666807/34224938-6e1a131c-e579-11e7-8126-44c25b5a06be.png)

Related PRs:
https://github.com/twitter/twitter-kit-ios/pull/9

I think this is a better fix than that PR because it only re-calculates the number of lines, instead of re-configuring the whole view for the tweet contents every time the view is laid out.