### PR TITLE
Fix test failing

### DIFF
--- a/TwitterKit/TwitterKitTests/SocialTests/Syndication/Views/TWTRTimestampLabelTests.m
+++ b/TwitterKit/TwitterKitTests/SocialTests/Syndication/Views/TWTRTimestampLabelTests.m
@@ -21,6 +21,8 @@
 #import "TWTRFixtureLoader.h"
 #import "TWTRTimestampLabel.h"
 #import "TWTRTweet.h"
+#import <TwitterCore/TWTRDateFormatters.h>
+#import <TwitterCore/TWTRDateFormatters_Private.h>
 
 @interface TWTRTimestampLabelTests : XCTestCase
 
@@ -37,6 +39,9 @@
 - (void)setUp
 {
     [super setUp];
+    
+    [TWTRDateFormatters resetCache];
+    [TWTRDateFormatters setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US"]];
 
     self.timestamp = [[TWTRTimestampLabel alloc] init];
 


### PR DESCRIPTION
The test has always failed in the following, so I fixed it to set the locale of `TWTRDateFormatter` before tests has started.
This PR is a really small changes.

https://github.com/twitter/twitter-kit-ios/blob/master/TwitterKit/TwitterKitTests/SocialTests/Syndication/Views/TWTRTimestampLabelTests.m#L79
https://github.com/twitter/twitter-kit-ios/blob/master/TwitterKit/TwitterKitTests/SocialTests/Syndication/Views/TWTRTimestampLabelTests.m#L82