### PR TITLE
Fixed that the ViewController passed to the login function was strong captured

### DIFF
--- a/TwitterKit/TwitterKit/TWTRTwitter.m
+++ b/TwitterKit/TwitterKit/TWTRTwitter.m
@@ -356,6 +356,8 @@ static TWTRTwitter *sharedTwitter;
     } else {
         [self.scribeSink didStartOAuthLogin];
 
+        __weak typeof(viewController) weakViewController = viewController;
+        
         self.mobileSSO = [[TWTRMobileSSO alloc] initWithAuthConfig:self.sessionStore.authConfig];
         [self.mobileSSO attemptAppLoginWithCompletion:^(TWTRSession *session, NSError *error) {
             if (session) {
@@ -365,9 +367,10 @@ static TWTRTwitter *sharedTwitter;
                     // The user tapped "Cancel"
                     completion(session, error);
                 } else {
+                    typeof(viewController) strongViewController = weakViewController;
                     // There wasn't a Twitter app
                     [[TWTRTwitter sharedInstance].scribeSink didFailSSOLogin];
-                    [self performWebBasedLogin:viewController completion:completion];
+                    [self performWebBasedLogin:strongViewController completion:completion];
                 }
             }
         }];
@@ -384,12 +387,15 @@ static TWTRTwitter *sharedTwitter;
 
     self.webAuthenticationFlow = [[TWTRWebAuthenticationFlow alloc] initWithSessionStore:self.sessionStore];
 
+    __weak typeof(viewController) weakViewController = viewController;
     [self.webAuthenticationFlow beginAuthenticationFlow:^(UIViewController *controller) {
+        typeof(viewController) strongViewController = weakViewController;
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:controller];
-        [viewController presentViewController:navigationController animated:YES completion:nil];
+        [strongViewController presentViewController:navigationController animated:YES completion:nil];
     }
         completion:^(TWTRSession *session, NSError *error) {
-            [viewController dismissViewControllerAnimated:YES completion:nil];
+            typeof(viewController) strongViewController = weakViewController;
+            [strongViewController dismissViewControllerAnimated:YES completion:nil];
             completion(session, error);
         }];
 }

--- a/TwitterKit/TwitterKitTests/SocialTests/TwitterSocialTests.m
+++ b/TwitterKit/TwitterKitTests/SocialTests/TwitterSocialTests.m
@@ -170,6 +170,16 @@
     OCMVerifyAll(mockTwitterKit);
 }
 
+- (void)testLoginWithViewController_releaseViewControllerAfterLogin
+{
+    UIViewController *viewController = [[UIViewController alloc] init];
+    __weak typeof(viewController) weakViewController = viewController;
+    [self.twitterKit logInWithViewController:viewController completion:^(TWTRSession *_Nullable session, NSError *_Nullable error){
+    }];
+    viewController = nil;
+    XCTAssertNil(weakViewController);
+}
+
 - (void)testLogout_clearsWebViewCookies
 {
     [self.twitterKit.sessionStore saveSession:self.session


### PR DESCRIPTION
A ViewController that passed to `TWTR Twitter.sharedInstance.logInwithcompletion:)` is never release after that because it was being strong captured by sharedInstance.

I fixed this, so a ViewController is now **weak** referenced by sharedInstance.

It confirmed by the demo app, and added test.

Perhaps the issue below is due to this.
https://github.com/twitter/twitter-kit-ios/issues/8

Thanks in advance👍 