### PR TITLE
Fix modal-on-modal dismiss bug

### DIFF
--- a/TwitterKit/TwitterKit/TWTRTwitter.m
+++ b/TwitterKit/TwitterKit/TWTRTwitter.m
@@ -389,7 +389,9 @@ static TWTRTwitter *sharedTwitter;
         [viewController presentViewController:navigationController animated:YES completion:nil];
     }
         completion:^(TWTRSession *session, NSError *error) {
-            [viewController dismissViewControllerAnimated:YES completion:nil];
+            // Dismiss from `presentedViewController` so that `viewController` itself doesn't get dismissed
+            // when it is also a `presentedViewController` of another presenting (parent) view controller.
+            [viewController.presentedViewController dismissViewControllerAnimated:YES completion:nil];
             completion(session, error);
         }];
 }


### PR DESCRIPTION
There is a minor UI bug when `performWebBasedLogin` is called **from modal view controller**.

For example, when `SFSafariViewController` (login screen, modal-on-modal) gets cancelled, `dismiss` is eventually called on safari's `presentingViewController`, not safari itself.
This will eventually dismiss both modals at the same time.

Please see repro code for more detail (comments are included): 
https://github.com/inamiy/twitter-kit-ios/commit/04b74159b648e1ff642fb6819b429e85b78105b9