### PR TITLE
fix handling of SFSafariViewController redirect when user cancels aut…

### DIFF
--- a/TwitterKit/TwitterKit/Social/Identity/TWTRLoginURLParser.m
+++ b/TwitterKit/TwitterKit/Social/Identity/TWTRLoginURLParser.m
@@ -80,6 +80,9 @@
 {
     NSDictionary *parameters = [TWTRNetworkingUtil parametersFromQueryString:url.absoluteString];
     NSString *token = parameters[TWTRAuthOAuthTokenKey];
+    if (token == nil) {
+        token = parameters[TWTRAuthAppOAuthDeniedKey];
+    }
 
     return [[[TWTRTwitter sharedInstance] sessionStore] isValidOauthToken:token];
 }


### PR DESCRIPTION
…hentication.

The code that processes the URL used to redirect to the app after the web authentication expects a "oauth_token" parameter.

However, if the user cancels the sign-in procedure and clicks the "Return to \<app\>" button, the URL doesn't contain such a parameter; it only contains a "denied" parameter, whose argument is the aoth token. I.e.: "twitterkit-\<consumer key\>://callback?app=\<consumer key\>&denied=\<oauth token\>".

This change looks for the "denied" parameter in case the "oath_token" parameter can't be found, so that the redirect can complete successfully.
