### PR TITLE
Use the safe area layout guide for bottom video controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Make sure that the run script phase is after your Link Binaries with Libraries p
 
 Twitter Kit includes a demonstration app allowing you to preview features, and verify functionality. Create Twitter API keys as above, and then:
 
-* To check out a demo app with features already built in, rename `DemoApp/Config.xcconfig.sample` to `DemoApp/Config.xcconfig` and populate the consumer key and secret.
+* To check out a demo app with features already built in, rename `DemoApp/Config.xcconfig.example` to `DemoApp/Config.xcconfig` and populate the consumer key and secret.
 * Run `DemoApp.xcworkspace` on Xcode to verify build.
 
 ## Code of conduct

--- a/TwitterKit/TwitterKit/Social/Syndication/Controllers/TWTRVideoPlayerView.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/Controllers/TWTRVideoPlayerView.m
@@ -80,7 +80,13 @@ NS_ASSUME_NONNULL_BEGIN
     NSDictionary *views = NSDictionaryOfVariableBindings(bottomBar);
 
     [TWTRViewUtil addVisualConstraints:@"H:|[bottomBar]|" views:views];
-    [TWTRViewUtil addVisualConstraints:@"V:[bottomBar(60)]|" views:views];
+    [TWTRViewUtil addVisualConstraints:@"V:[bottomBar(60)]" views:views];
+    
+    if (@available(iOS 11, *)) {
+        [bottomBar.bottomAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.bottomAnchor].active = YES;
+    } else {
+        [TWTRViewUtil constraintToBottomOfSuperview:bottomBar].active = YES;
+    }
 
     _bottomBarContainer = bottomBar;
 


### PR DESCRIPTION
On iPhone X, this will raise the `bottomBar` above the home indicator. On all other [current] devices, the `bottomBar` will remain pinned to the bottom of the superview.

Also fixes the incorrect name of the example `xcconfig` file for the demo app.