### PR TITLE
Fix inline player auto layout.

### DIFF
--- a/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetMediaView.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/Views/TWTRTweetMediaView.m
@@ -110,6 +110,7 @@ static const CGFloat TWTRImageCornerRadius = 4.0;
         self.inlinePlayerView.shouldSetChromeVisible = NO;
         self.inlinePlayerView.delegate = self;
         self.inlinePlayerView.aspectRatio = TWTRVideoPlayerAspectRatioAspectFill;
+        self.inlinePlayerView.translatesAutoresizingMaskIntoConstraints = NO;
         [self insertSubview:self.inlinePlayerView belowSubview:[self videoThumbnail]];
     } else {
         [self.inlinePlayerView removeFromSuperview];


### PR DESCRIPTION
Problem

When debugging in Xcode, TWTRTweetView instances containing inline video/animated-gif views are causing broken auto layout constraints.

Solution

The `inlinePlayerView` needs to have `translatesAutoresizingMastIntoConstraints = NO` before being added as a subview to the parent `TWTRTweetMediaView`.