### PR TITLE
Fix close button on media view for iPhone X

### DIFF
--- a/TwitterKit/TwitterKit/Social/Syndication/Controllers/TWTRMediaContainerViewController.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/Controllers/TWTRMediaContainerViewController.m
@@ -99,7 +99,11 @@ NS_ASSUME_NONNULL_BEGIN
     NSDictionary *views = NSDictionaryOfVariableBindings(topBar);
 
     [TWTRViewUtil addVisualConstraints:@"H:|[topBar]|" views:views];
-    [TWTRViewUtil addVisualConstraints:@"V:|[topBar]" views:views];
+    if (@available(iOS 11, *)) {
+      [topBar.topAnchor constraintEqualToAnchor: self.view.safeAreaLayoutGuide.topAnchor].active = YES;
+    } else {
+      [TWTRViewUtil addVisualConstraints:@"V:|[topBar]" views:views];
+    }
 
     UIBarButtonItem *button = [self makeCloseButton];
     UINavigationItem *item = [[UINavigationItem alloc] init];


### PR DESCRIPTION
Problem

Currently, after clicking a photo or video from a timeline tweet,
you can not close the media view controller on the iPhone X. The
close button overlaps the status bar and does not respond to user
interaction.

Solution

This code uses the safe area layout guide in iOS 11 to
constrain the top of the close button to the top of the safe area. 
If the device is not an iOS 11 device, the close button defaults 
to the previously functional visual constraints.
