### PR TITLE
Update Readme.md, Carthage installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ binary "https://ton.twimg.com/syndication/twitterkit/ios/TwitterKit.json"
 binary "https://ton.twimg.com/syndication/twitterkit/ios/TwitterCore.json"
 ```
 
-After running `carthage update`, add `TwitterKit.framework` and `TwitterShareExtensionUI.framework` to the `Linked Frameworks and Binaries` section under General of your App target. In addition to that, make sure that when you are adding the copy-frameworks run script for Carthage that you add the following input paths: 
+After running `carthage update`, add `TwitterKit.framework`, `TwitterCore.framework` and `TwitterShareExtensionUI.framework` to the `Linked Frameworks and Binaries` section under General of your App target. In addition to that, make sure that when you are adding the copy-frameworks run script for Carthage that you add the following input paths: 
 
 ```
 $(SRCROOT)/Carthage/Build/iOS/TwitterCore.framework


### PR DESCRIPTION
In Carthage installation process, after running 'carthage update', instructions do not include TwitterCore.framework in 'Linked Frameworks and Binaries' but is required to make things work.

Problem

Twitter-Kit does not work properly if TwitterCore.framework is not linked with project.

Solution

I mentioned that TwitterCore.framework was required in Linked Frameworks and Binaries section.

Result

Carthage installation instruction are more precise.
