### PR TITLE
Fix infinity loop when break layout on iPhoneX, happend when share sc…

### DIFF
--- a/TwitterKit/TwitterShareExtensionUI/TwitterShareExtensionUI/Private/Composer/TWTRSETweetComposerViewController.m
+++ b/TwitterKit/TwitterShareExtensionUI/TwitterShareExtensionUI/Private/Composer/TWTRSETweetComposerViewController.m
@@ -292,9 +292,9 @@ static void *TSETweetTextKVOCOntext = &TSETweetTextKVOCOntext;
 
     self.scrollView.alwaysBounceVertical = YES;
 
-    if (@available(iOS 11.0, *)) {
-        self.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
-    }
+//    if (@available(iOS 11.0, *)) {
+//        self.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+//    }
 
     self.tableView.bounces = NO;
 
@@ -435,7 +435,7 @@ static void *TSETweetTextKVOCOntext = &TSETweetTextKVOCOntext;
     if (@available(iOS 11.0, *)) {
         _scrollViewTopConstraint.active = NO;
         _scrollViewTopConstraint = [_scrollView.topAnchor constraintEqualToAnchor:self.view.topAnchor
-                                                                         constant:self.navigationController.navigationBar.frame.size.height];
+                                                                         constant:0.0f];
         _scrollViewTopConstraint.active = YES;
     }
     _tableViewHeightConstraint.active = NO;


### PR DESCRIPTION
…reenshot iPhoneX

Problem

When capture and share screenshot iPhoneX, screen have been locked (infinity loop) due to breaking layout

Solution

Convert contentInsetAdjustmentBehavior to default