### PR TITLE
Increased max tweet length to 280

### DIFF
--- a/TwitterKit/TwitterKit/Social/Syndication/ThirdParty/TWTRTwitterText.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/ThirdParty/TWTRTwitterText.m
@@ -240,7 +240,7 @@
 
 #pragma mark - Constants
 
-static const NSUInteger MaxTweetLength = 140;
+static const NSUInteger MaxTweetLength = 280;
 static const NSUInteger HTTPShortURLLength = 23;
 static const NSUInteger HTTPSShortURLLength = 23;
 


### PR DESCRIPTION
Problem

The maximum tweet length is still set to 140 when it should be 280

Solution

Increased the max length

Result

Tested composing a tweet and there is no unexpected change in behavior
