### PR TITLE
FIX : Return YES if the SSO login isMobileSSOSuccess

### DIFF
--- a/TwitterKit/TwitterKit/TWTRTwitter.m
+++ b/TwitterKit/TwitterKit/TWTRTwitter.m
@@ -384,7 +384,9 @@ static TWTRTwitter *sharedTwitter;
     BOOL isWeb = [self.mobileSSO isWebWithSourceApplication:sourceApplication];
 
     if (isSSOBundle) {
-        [self.mobileSSO processRedirectURL:url];
+        if ([self.mobileSSO processRedirectURL:url]){
+            return YES;
+        }
     } else if (isWeb) {
         BOOL isTokenValid = [self.mobileSSO verifyOauthTokenResponsefromURL:url];
         if (isTokenValid) {


### PR DESCRIPTION
Problem

I was not able to properly finalize a login with a Twitter account using Firebase. The Twitter login is actually impossible to enable with the FirebaseUI auth providers.
I noticed an error in your management of OpenUrl in the application delegate

Solution

Say YES when TwitterKit is challenged to open an URL and the SSO is a success. TwitterKit has done the job!

Result

Avoid a crash on the providers loop on the Firebase UI SDK because the SDK will try to find a provider to handle the asked openUrl and your SDK has complete the job 👍 

